### PR TITLE
Add Support for Python 3 and using Flask test request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ from myapp import app, db
 from flask.ext.fixtures import Fixtures
 
 app.config.from_object('myapp.config.TestConfig')
-fixtures = Fixtures(app, db)
+fixtures = Fixtures(app, db, use_test_request_context=True)
 
 # In this example, we'll decorate the entire class. This way the fixtures we
 # have in the `foo_tests.yml` file are loaded into the test database at class

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 
 from __future__ import print_function
 
-import abc
 import functools
 import glob
 import importlib

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -97,6 +97,7 @@ class Fixtures(object):
   def teardown(self):
     print("tearing down fixtures...")
     self.db.session.expunge_all()
+    self.db.session.commit()
     self.db.drop_all()
 
   def load_fixtures(self, fixtures):
@@ -150,7 +151,7 @@ class Fixtures(object):
         with self.app.test_request_context():
           self.setup(fixtures)
       else:
-          self.setup(fixtures)
+        self.setup(fixtures)
       try:
         method(*args, **kwargs)
       finally:

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -47,12 +47,13 @@ TEST_TEARDOWN_NAMES = ('tearDown',)
 
 
 class Fixtures(object):
-  def __init__(self, app, db):
-    self.init_app(app, db)
+  def __init__(self, app, db, use_test_request_context=False):
+    self.init_app(app, db, use_test_request_context)
 
-  def init_app(self, app, db):
+  def init_app(self, app, db, use_test_request_context):
     self.app = app
     self.db = db
+    self.use_test_request_context = use_test_request_context
 
   @property
   def fixtures_dirs(self):
@@ -69,10 +70,16 @@ class Fixtures(object):
 
   def setup(self, fixtures):
     print("setting up fixtures...")
-    # Setup the database
-    self.db.create_all()
-    # TODO why do we call this?
-    self.db.session.rollback()
+    if self.use_test_request_context:
+      with self.app.test_request_context():
+        # Setup the database
+        self.db.create_all()
+        # TODO why do we call this?
+        self.db.session.rollback()
+      # Setup the database
+      self.db.create_all()
+      # TODO why do we call this?
+      self.db.session.rollback()
 
     # Load all of the fixtures
     for filename in fixtures:

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -70,17 +70,10 @@ class Fixtures(object):
 
   def setup(self, fixtures):
     print("setting up fixtures...")
-    if self.use_test_request_context:
-      with self.app.test_request_context():
-        # Setup the database
-        self.db.create_all()
-        # TODO why do we call this?
-        self.db.session.rollback()
-    else:
-      # Setup the database
-      self.db.create_all()
-      # TODO why do we call this?
-      self.db.session.rollback()
+    # Setup the database
+    self.db.create_all()
+    # TODO why do we call this?
+    self.db.session.rollback()
 
     # Load all of the fixtures
     for filename in fixtures:
@@ -153,7 +146,11 @@ class Fixtures(object):
       fixtures = self.find_fixtures(method, fixtures)
 
     def wrapper(*args, **kwargs):
-      self.setup(fixtures)
+      if self.use_test_request_context:
+        with self.app.test_request_context()
+          self.setup(fixtures)
+      else:
+          self.setup(fixtures)
       try:
         method(*args, **kwargs)
       finally:

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -147,7 +147,7 @@ class Fixtures(object):
 
     def wrapper(*args, **kwargs):
       if self.use_test_request_context:
-        with self.app.test_request_context()
+        with self.app.test_request_context():
           self.setup(fixtures)
       else:
           self.setup(fixtures)

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -196,7 +196,8 @@ class Fixtures(object):
     # of fixtures to install. In that case, we set the fixtures variable to an
     # empty list and the wrapped_obj variable to the object being decorated so
     # we can call the decorator on it later.
-    if len(fixtures) == 1 and not isinstance(fixtures[0], basestring):
+    string_type = basestring if sys.version_info < (3, 0) else str
+    if len(fixtures) == 1 and not isinstance(fixtures[0], string_type):
       wrapped_obj = fixtures[0]
       fixtures = ()
 

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -76,6 +76,7 @@ class Fixtures(object):
         self.db.create_all()
         # TODO why do we call this?
         self.db.session.rollback()
+    else:
       # Setup the database
       self.db.create_all()
       # TODO why do we call this?

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except:
 
 setup(
     name='Flask-Fixtures',
-    version='0.3.1',
+    version='0.3.2',
     url='https://github.com/croach/Flask-Fixtures',
     license='MIT License',
     author='Christopher Roach',


### PR DESCRIPTION
It is useful to have the ability to use the Flask test request context to avoid errors with the db object not being bound to any application context while testing. Also, made a simple change which makes the project compatible with Python 3.