### PR TITLE
Adds compatibility for Python 3

### DIFF
--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -9,6 +9,7 @@
     :copyright: (c) 2015 Christopher Roach <ask.croach@gmail.com>.
     :license: MIT, see LICENSE for more details.
 """
+from __future__ import absolute_import
 
 import logging
 import os
@@ -17,6 +18,8 @@ from sqlalchemy import Table
 
 from . import loaders
 from .utils import can_persist_fixtures
+import six
+import importlib
 
 try:
     import simplejson as json
@@ -73,7 +76,7 @@ def load_fixtures(db, fixtures):
     for fixture in fixtures:
         if 'model' in fixture:
             module_name, class_name = fixture['model'].rsplit('.', 1)
-            module = __import__(module_name, globals(), locals(), [class_name], -1)
+            module = importlib.import_module(module_name)
             model = getattr(module, class_name)
             for fields in fixture['records']:
                 obj = model(**fields)
@@ -189,9 +192,7 @@ class MetaFixturesMixin(type):
             return default_fn
 
 
-class FixturesMixin(object):
-
-    __metaclass__ = MetaFixturesMixin
+class FixturesMixin(six.with_metaclass(MetaFixturesMixin, object)):
 
     fixtures = None
 

--- a/flask_fixtures/loaders.py
+++ b/flask_fixtures/loaders.py
@@ -7,12 +7,14 @@
     :copyright: (c) 2015 Christopher Roach <ask.croach@gmail.com>.
     :license: MIT, see LICENSE for more details.
 """
+from __future__ import absolute_import
 
 import abc
 import os
 import logging
 
 from .utils import print_info
+import six
 
 try:
     from dateutil.parser import parse as dtparse
@@ -43,9 +45,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-class FixtureLoader(object):
-    __metaclass__ = abc.ABCMeta
-
+class FixtureLoader(six.with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def load(self):
         pass
@@ -57,7 +57,7 @@ class JSONLoader(FixtureLoader):
 
     def load(self, filename):
         def _datetime_parser(dct):
-            for key, value in dct.items():
+            for key, value in list(dct.items()):
                 try:
                     dct[key] = dtparse(value)
                 except Exception:

--- a/flask_fixtures/utils.py
+++ b/flask_fixtures/utils.py
@@ -9,6 +9,8 @@
 """
 
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
 
 import inspect
 import os
@@ -21,7 +23,7 @@ def print_msg(msg, header, file=sys.stdout):
 
     # Calculate the length of the boarder on each side of the header and the
     # total length of the bottom boarder
-    side_boarder_length = (DEFAULT_MSG_BLOCK_WIDTH - (len(header) + 2)) / 2
+    side_boarder_length = (DEFAULT_MSG_BLOCK_WIDTH - (len(header) + 2)) // 2
     msg_block_width = side_boarder_length * 2 + (len(header) + 2)
 
     # Create the top and bottom boarders
@@ -32,7 +34,7 @@ def print_msg(msg, header, file=sys.stdout):
     def pad(line, length):
         """Returns a string padded and centered by the given length"""
         padding_length = length - len(line)
-        left_padding = ' ' * (padding_length/2)
+        left_padding = ' ' * (padding_length//2)
         right_padding = ' ' * (padding_length - len(left_padding))
         return '{0} {1} {2}'.format(left_padding, line, right_padding)
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Flask-Fixtures
 
 A fixtures library for testing Flask apps.
 """
+from __future__ import absolute_import
 
 import os
 import subprocess
@@ -21,6 +22,16 @@ try:
 except:
     README = __doc__
 
+install_requires = [
+                       'Flask',
+                       'Flask-SQLAlchemy',
+                       'six'
+                   ]
+try:
+    import importlib
+except ImportError:
+    install_requires.append('importlib')
+
 setup(
     name='Flask-Fixtures',
     version='0.3.4',
@@ -35,14 +46,12 @@ setup(
     # py_modules=['flask_fixtures'],
     # if you would be using a package instead use packages instead
     # of py_modules:
+    install_requires=install_requires,
     packages=['flask_fixtures'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=[
-        'Flask',
-        'Flask-SQLAlchemy'
-    ],
+
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/tests/myapp/__init__.py
+++ b/tests/myapp/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # myapp/__init__.py
 
 from flask import Flask

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # myapp/models.py
 
 from flask.ext.sqlalchemy import SQLAlchemy

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # myapp/fixtures/test_fixtures.py
 
 import unittest

--- a/tests/test_persist_fixtures.py
+++ b/tests/test_persist_fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import datetime
 import inspect
 import os
@@ -43,7 +45,7 @@ if can_persist_fixtures():
             assert Book.query.count() == 5
 
         def test_one(self):
-            print "Inside test_one"
+            print("Inside test_one")
             # Add another author on the fly
             author = Author()
             author.first_name = 'George'
@@ -59,7 +61,7 @@ if can_persist_fixtures():
             self.db.session.commit()
 
         def test_two(self):
-            print "Inside test_two"
+            print("Inside test_two")
             # Add another author on the fly
             author = Author()
             author.first_name = 'Aldous'


### PR DESCRIPTION
This should fix #7 

I ran the tests with Python 2.6, Python 2.7 and Python 3.4 and they all ran fine

Updating involved:

* Running [python-modernize](https://pypi.python.org/pypi/modernize) for all trivial changes (adds a 'six' dependency)
* Using explicit integer division for calculating borders in logging
* Using importlib for importing modules by name (adds 'importlib' requirement for Python 2.6)