### PR TITLE
About fixtures directory set problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .cache
 build
 dist
+.DS_Store

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -91,16 +91,17 @@ def setup(obj):
     # Rollback any lingering transactions
     obj.db.session.rollback()
 
-
     # Construct a list of paths within which fixtures may reside
     default_fixtures_dir = os.path.join(current_app.root_path, 'fixtures')
 
     # All relative paths should be relative to the app's root directory.
-    fixtures_dirs = [default_fixtures_dir]
+    fixtures_dirs = []
     for directory in current_app.config.get('FIXTURES_DIRS', []):
         if not os.path.isabs(directory):
             directory = os.path.abspath(os.path.join(current_app.root_path, directory))
         fixtures_dirs.append(directory)
+
+    fixtures_dirs.append(default_fixtures_dir)
 
     # Load all of the fixtures
     for filename in obj.fixtures:

--- a/tests/fixtures/authors.json
+++ b/tests/fixtures/authors.json
@@ -1,0 +1,29 @@
+[
+    {
+        "table": "author",
+        "records": [
+        {
+            "id": 1,
+            "first_name": "Feng",
+            "last_name": "Yao"
+        }]
+    },
+    {
+        "model": "myapp.models.Book",
+        "records": [{
+            "title": "Neuromancer",
+            "author_id": 1,
+            "published_date": "1984-07-01"
+        },
+        {
+            "title": "Count Zero",
+            "author_id": 1,
+            "published_date": "1986-03-01"
+        },
+        {
+            "title": "Mona Lisa Overdrive",
+            "author_id": 1,
+            "published_date": "1988-10-01"
+        }]
+    }
+]

--- a/tests/test_default_fixtures_dir.py
+++ b/tests/test_default_fixtures_dir.py
@@ -1,0 +1,51 @@
+"""
+    test_default_fixtures_dir
+    ~~~~~~~~~~~~~
+
+    A set of tests that check the default fixtures directory of Flask-Fixtures.
+
+    :copyright: (c) 2016 Feng Yao <yaoelvon@gmail.com>.
+    :license: MIT, see LICENSE for more details.
+"""
+
+
+from __future__ import absolute_import
+
+import unittest
+
+from myapp import app
+from myapp.models import db, Author
+
+from flask.ext.fixtures import FixturesMixin
+
+
+class TestDefaultFixturesDir(unittest.TestCase, FixturesMixin):
+    '''Test fixtures directory set problem.
+    When coder set app.config['FIXTURES_DIRS'] and FIXTURES_DIRS path
+    and "current_app.root_path + '/fixtures'" together have
+    a same file like 'author.json', flask-fixtures will get
+    "current_app.root_path + '/fixtures/author.json'" file.
+    I think that default can use "current_app.root_path + '/fixtures'",
+    but we shoud use app.config['FIXTURES_DIRS']
+    when coder had set "app.config['FIXTURES_DIRS']".
+    '''
+    app = app
+    db = db
+    app.config['FIXTURES_DIRS'] = [app.root_path + '/../fixtures']
+    fixtures = ['authors.json']
+
+    def setUp(self):
+        self.SUT_app = app
+        self.app_context = self.SUT_app.app_context()
+        self.app_context.push()
+        app.logger.debug('app.root_path={0}'.format(app.config['FIXTURES_DIRS']))
+
+    def tearDown(self):
+        app.config['FIXTURES_DIRS'] = ''
+        self.app_context.pop()
+
+    def test_get_authors_json_from_dir_set(self):
+        author = Author.query.first()
+
+        self.assertEqual(author.first_name, 'Feng')
+        self.assertEqual(author.last_name, 'Yao')


### PR DESCRIPTION
When I set app.config['FIXTURES_DIRS'], FIXTURES_DIRS path and "current_app.root_path + '/fixtures'" together have a same file 'author.json', flask-fixtures will get "current_app.root_path + '/fixtures/author.json'" file. 
I think that default can use "current_app.root_path + '/fixtures'", but we shoud use app.config['FIXTURES_DIRS'] when I had set "app.config['FIXTURES_DIRS']".