### PR TITLE
Make log to a file instead of stdout

### DIFF
--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -38,7 +38,7 @@ __version__ = '0.3.7'
 
 # Configure the root logger for the library
 logger_format_string = '[%(levelname)s] %(message)s in File "%(pathname)s", line %(lineno)d, in %(funcName)s'
-logging.basicConfig(format=logger_format_string, level=logging.INFO)
+logging.basicConfig(format=logger_format_string, level=logging.INFO, filename='flask_fixtures.log')
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
I started using `Flask-Fixtures` today and I'm loving it! But the only thing I would change right now is the log output to stdout.

I prefer this output:
```
...........
----------------------------------------------------------------------
Ran 11 tests in 0.362s

OK
```

Over this one:
```
[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/...//lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/alex-api/lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/...lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.[INFO] setting up fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 84, in setup
[INFO] tearing down fixtures... in File "/Users/mrosa/.virtualenvs/.../lib/python3.5/site-packages/flask_fixtures/__init__.py", line 119, in teardown
.
----------------------------------------------------------------------
Ran 11 tests in 0.353s

OK
```

So this PR sets the `filename` parameter in the `logging.basicConfig()` call so log messages won't mess with the output from `unittest` or `py.test`.

If there is another way to do this, please, let me know! 😉 