### PR TITLE
Add custom loaders manually with priority during execution

### DIFF
--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+
+from flask_fixtures.loaders import load, FixtureLoader, add, remove
+
+from myapp import app
+
+
+class CustomJSONLoader(FixtureLoader):
+    extensions = ('.json',)
+
+    def load(self, filename):
+        return ["foo"]
+
+
+class TestLoaders(unittest.TestCase):
+
+    def test_only_loader_can_be_added(self):
+        self.assertRaises(ValueError, add, {})
+
+    def test_custom_loader_is_used_first(self):
+        add(CustomJSONLoader)
+        path = os.path.join(app.root_path, "fixtures", "authors.json")
+        data = load(path)
+        remove(CustomJSONLoader)
+
+        assert ["foo"] == data

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ commands =
 deps =
     flask-pre-app-ctx: Flask < 0.9
     flask-post-app-ctx: Flask > 0.9
+    flask-pre-app-ctx: Flask-SQLAlchemy < 2.0
+    flask-post-app-ctx: Flask-SQLAlchemy > 2.0
     discover
     nose
     pytest


### PR DESCRIPTION
Hi @croach,

I added way how to use custom Loaders instead of only relying on `FixtureLoader.__subclasses__()`. Custom loaders will take precedence over the loaders provided by the library.

This PR depends on #31.