### PR TITLE
Restrict dependencies for pre context flask

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ commands =
 deps =
     flask-pre-app-ctx: Flask < 0.9
     flask-post-app-ctx: Flask > 0.9
+    flask-pre-app-ctx: Flask-SQLAlchemy < 2.0
+    flask-post-app-ctx: Flask-SQLAlchemy > 2.0
     discover
     nose
     pytest


### PR DESCRIPTION
Hi @croach,

Flask-SQLAlchemy since version 2.1 require Flask 0.10. thus I updated tox definition for pre context environments.