### PR TITLE
Avoid parsing datetime in json

### DIFF
--- a/flask_fixtures/config.py
+++ b/flask_fixtures/config.py
@@ -1,0 +1,12 @@
+JSON_PARSE_DATETIME = 'loaders.json.parse_datetime'
+
+_default_settings = {
+    JSON_PARSE_DATETIME: True
+}
+
+settings = _default_settings.copy()
+
+
+def reset():
+    global settings
+    settings = _default_settings.copy()

--- a/flask_fixtures/loaders.py
+++ b/flask_fixtures/loaders.py
@@ -13,6 +13,8 @@ import abc
 import os
 import logging
 
+from flask_fixtures import config
+from flask_fixtures.config import JSON_PARSE_DATETIME
 from .utils import print_info
 import six
 
@@ -65,7 +67,11 @@ class JSONLoader(FixtureLoader):
             return dct
 
         with open(filename) as fin:
-            return json.load(fin, object_hook=_datetime_parser)
+            parse_datetime = config.settings.get(JSON_PARSE_DATETIME)
+            if parse_datetime:
+                return json.load(fin, object_hook=_datetime_parser)
+            else:
+                return json.load(fin)
 
 
 class YAMLLoader(FixtureLoader):

--- a/tests/myapp/fixtures/dates.json
+++ b/tests/myapp/fixtures/dates.json
@@ -1,0 +1,10 @@
+[
+  {
+    "table": "dates",
+    "records": [
+      {
+        "published_date": "1984-07-01"
+      }
+    ]
+  }
+]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from datetime import datetime
+
+from flask_fixtures import config
+from flask_fixtures.config import JSON_PARSE_DATETIME
+from flask_fixtures.loaders import JSONLoader
+
+from myapp import app
+
+
+class TestLoaders(unittest.TestCase):
+
+    def tearDown(self):
+        config.reset()
+
+    def test_datetime_parsing_in_json(self):
+        def assert_datetime(expected_value):
+            path = os.path.join(app.root_path, "fixtures", "dates.json")
+            json_loader = JSONLoader()
+            data = json_loader.load(path)
+
+            assert expected_value == data[0]['records'][0]['published_date']
+
+        config.settings[JSON_PARSE_DATETIME] = True
+        assert_datetime(datetime(1984, 7, 1))
+
+        config.settings[JSON_PARSE_DATETIME] = False
+        assert_datetime("1984-07-01")

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ commands =
 deps =
     flask-pre-app-ctx: Flask < 0.9
     flask-post-app-ctx: Flask > 0.9
+    flask-pre-app-ctx: Flask-SQLAlchemy < 2.0
+    flask-post-app-ctx: Flask-SQLAlchemy > 2.0
     discover
     nose
     pytest


### PR DESCRIPTION
Hi @croach, 

`_datetime_parser` sometimes produce strange result so I added option to disable it for those who don't really need datetime objects. I left it enabled by default, so there is no BC.

This PR depends on #31.